### PR TITLE
Fix question update to keep false

### DIFF
--- a/src/api/question/question.service.ts
+++ b/src/api/question/question.service.ts
@@ -59,7 +59,7 @@ export class QuestionService implements IBasicService {
     });
 
     // update question
-    question.active = body.active || question.active;
+    question.active = body.active !== undefined ? body.active : question.active;
     question.text = body.text || question.text;
     question.answer = body.answer || question.answer;
     question.textWithoutSymbols = body.text ? cleanUpQuestion(body.text) : question.textWithoutSymbols;


### PR DESCRIPTION
## Summary
- fix question service update logic so boolean false values are stored
- Updated the question update logic so that an explicit false value is preserved rather than ignored, ensuring accurate status handling